### PR TITLE
Enhancement: Use --working-dir option when normalizing composer.json

### DIFF
--- a/src/Commands/Composer/Normalize.php
+++ b/src/Commands/Composer/Normalize.php
@@ -67,7 +67,7 @@ class Normalize extends AbstractCommand
 
     private function normalizeComposerFile($fname)
     {
-        $command = 'composer normalize --no-update-lock ' . $fname;
+        $command = 'composer normalize --no-update-lock --working-dir=' . dirname($fname);
 
         list($exit_code, $output, $exit_code_txt, $error) = $this->callShell($command, false);
 


### PR DESCRIPTION
This PR

* [x] uses the `--working-dir` option when invoking `composer normalize`

Related to https://github.com/localheinz/composer-normalize/issues/165.

💁‍♂️ Not sure, will this help?